### PR TITLE
fix: support Keycloak on non-standard ports + dev environment docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,7 +104,28 @@ FLASK_KEYCLOAK_REALM=robojackets
 
 ### Apiary Dependency
 
-The Apiary service (`https://my.robojackets.org`) is an external production API that performs OAuth token fetch at import time. Access may be IP-restricted. Without network access to Apiary, the Flask app cannot start. There is no mock mode.
+The Apiary service (`https://my.robojackets.org`) is an external production API that performs OAuth token fetch at import time. Access is IP-restricted — the cloud VM IP must be whitelisted on the Apiary nginx/CloudFront configuration. Without network access to Apiary, the Flask app cannot start. There is no mock mode. The required secrets (`FLASK_APIARY_CLIENT_ID`, `FLASK_APIARY_CLIENT_SECRET`, `FLASK_APIARY_BASE_URL`) are injected via the Cursor Cloud secrets mechanism.
+
+### Starting the Flask App (Cloud Dev)
+
+After Docker/Keycloak are running and Apiary is accessible:
+
+```sh
+FLASK_APP=checkpoint.py \
+FLASK_SECRET_KEY="dev-secret-key-12345" \
+FLASK_KEYCLOAK_METADATA_URL="http://localhost/realms/robojackets/.well-known/openid-configuration" \
+FLASK_KEYCLOAK_CLIENT_ID="checkpoint" \
+FLASK_KEYCLOAK_CLIENT_SECRET="checkpoint-secret" \
+FLASK_KEYCLOAK_ADMIN_CLIENT_ID="checkpoint-admin" \
+FLASK_KEYCLOAK_ADMIN_CLIENT_SECRET="checkpoint-admin-secret" \
+FLASK_KEYCLOAK_REALM="robojackets" \
+FLASK_CACHE_TYPE="SimpleCache" \
+FLASK_DEBUG="1" \
+FLASK_DATABASE_LOCATION="/tmp/checkpoint.db" \
+poetry run flask run --no-debugger --port 5000
+```
+
+A test user is pre-created in local Keycloak: `testuser` / `testpass123`.
 
 ### Gotchas
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,18 +74,18 @@ export NVM_DIR="/home/ubuntu/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nv
 
 ### Local Keycloak Setup (Docker)
 
-The app needs a Keycloak instance. For local/cloud dev, run one via Docker on **port 80** (the code uses `urlparse(...).hostname` which strips the port):
+The app needs a Keycloak instance. For local/cloud dev, run one via Docker (any port works):
 
 ```sh
 dockerd &>/var/log/dockerd.log &
 # Wait for Docker to start, then:
-docker run -d --name keycloak -p 80:8080 \
+docker run -d --name keycloak -p 8080:8080 \
   -e KC_BOOTSTRAP_ADMIN_USERNAME=admin \
   -e KC_BOOTSTRAP_ADMIN_PASSWORD=admin \
   quay.io/keycloak/keycloak:26.0 start-dev
 ```
 
-After Keycloak is ready (check `curl -s http://localhost/realms/master/.well-known/openid-configuration`), configure it:
+After Keycloak is ready (check `curl -s http://localhost:8080/realms/master/.well-known/openid-configuration`), configure it:
 
 1. Create realm `robojackets`
 2. Create OIDC client `checkpoint` (secret: `checkpoint-secret`) in the robojackets realm with redirect URI `http://localhost:5000/*`
@@ -94,7 +94,7 @@ After Keycloak is ready (check `curl -s http://localhost/realms/master/.well-kno
 
 Then use these env vars:
 ```
-FLASK_KEYCLOAK_METADATA_URL=http://localhost/realms/robojackets/.well-known/openid-configuration
+FLASK_KEYCLOAK_METADATA_URL=http://localhost:8080/realms/robojackets/.well-known/openid-configuration
 FLASK_KEYCLOAK_CLIENT_ID=checkpoint
 FLASK_KEYCLOAK_CLIENT_SECRET=checkpoint-secret
 FLASK_KEYCLOAK_ADMIN_CLIENT_ID=checkpoint-admin
@@ -113,7 +113,7 @@ After Docker/Keycloak are running and Apiary is accessible:
 ```sh
 FLASK_APP=checkpoint.py \
 FLASK_SECRET_KEY="dev-secret-key-12345" \
-FLASK_KEYCLOAK_METADATA_URL="http://localhost/realms/robojackets/.well-known/openid-configuration" \
+FLASK_KEYCLOAK_METADATA_URL="http://localhost:8080/realms/robojackets/.well-known/openid-configuration" \
 FLASK_KEYCLOAK_CLIENT_ID="checkpoint" \
 FLASK_KEYCLOAK_CLIENT_SECRET="checkpoint-secret" \
 FLASK_KEYCLOAK_ADMIN_CLIENT_ID="checkpoint-admin" \
@@ -132,5 +132,5 @@ A test user is pre-created in local Keycloak: `testuser` / `testpass123`.
 - `uwsgi` requires `python3-dev` and `build-essential` system packages to compile.
 - The `static/app.js` file is not committed; it must be built via `npm run build` before the Flask app can serve the frontend.
 - `pip install poetry` may fail on Ubuntu 24.04 due to a missing RECORD file for the system `packaging` package. Workaround: `pip3 install --break-system-packages --ignore-installed packaging` first.
-- Keycloak must run on port 80 (not 8080) because `checkpoint.py` uses `urlparse(...).hostname` (which drops port info) to construct admin API URLs.
+- Keycloak can run on any port (e.g. 8080). The code uses `urlparse(...).netloc` to preserve port info in constructed URLs.
 - Docker in the cloud VM requires `fuse-overlayfs` storage driver and `iptables-legacy` due to nested container constraints.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,8 +72,44 @@ Node.js 24.x is installed via nvm. Activate with:
 export NVM_DIR="/home/ubuntu/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" && nvm use 24
 ```
 
+### Local Keycloak Setup (Docker)
+
+The app needs a Keycloak instance. For local/cloud dev, run one via Docker on **port 80** (the code uses `urlparse(...).hostname` which strips the port):
+
+```sh
+dockerd &>/var/log/dockerd.log &
+# Wait for Docker to start, then:
+docker run -d --name keycloak -p 80:8080 \
+  -e KC_BOOTSTRAP_ADMIN_USERNAME=admin \
+  -e KC_BOOTSTRAP_ADMIN_PASSWORD=admin \
+  quay.io/keycloak/keycloak:26.0 start-dev
+```
+
+After Keycloak is ready (check `curl -s http://localhost/realms/master/.well-known/openid-configuration`), configure it:
+
+1. Create realm `robojackets`
+2. Create OIDC client `checkpoint` (secret: `checkpoint-secret`) in the robojackets realm with redirect URI `http://localhost:5000/*`
+3. Create service-account client `checkpoint-admin` (secret: `checkpoint-admin-secret`) in the **master** realm
+4. Assign `manage-users`, `view-users`, `manage-realm`, `view-realm`, `manage-clients`, `view-clients` roles from both `master-realm` and `robojackets-realm` clients to the checkpoint-admin service account
+
+Then use these env vars:
+```
+FLASK_KEYCLOAK_METADATA_URL=http://localhost/realms/robojackets/.well-known/openid-configuration
+FLASK_KEYCLOAK_CLIENT_ID=checkpoint
+FLASK_KEYCLOAK_CLIENT_SECRET=checkpoint-secret
+FLASK_KEYCLOAK_ADMIN_CLIENT_ID=checkpoint-admin
+FLASK_KEYCLOAK_ADMIN_CLIENT_SECRET=checkpoint-admin-secret
+FLASK_KEYCLOAK_REALM=robojackets
+```
+
+### Apiary Dependency
+
+The Apiary service (`https://my.robojackets.org`) is an external production API that performs OAuth token fetch at import time. Access may be IP-restricted. Without network access to Apiary, the Flask app cannot start. There is no mock mode.
+
 ### Gotchas
 
 - `uwsgi` requires `python3-dev` and `build-essential` system packages to compile.
 - The `static/app.js` file is not committed; it must be built via `npm run build` before the Flask app can serve the frontend.
 - `pip install poetry` may fail on Ubuntu 24.04 due to a missing RECORD file for the system `packaging` package. Workaround: `pip3 install --break-system-packages --ignore-installed packaging` first.
+- Keycloak must run on port 80 (not 8080) because `checkpoint.py` uses `urlparse(...).hostname` (which drops port info) to construct admin API URLs.
+- Docker in the cloud VM requires `fuse-overlayfs` storage driver and `iptables-legacy` due to nested container constraints.

--- a/checkpoint.py
+++ b/checkpoint.py
@@ -135,7 +135,7 @@ keycloak = OAuth2Session(
     token_endpoint=urlunparse(
         (
             urlparse(app.config["KEYCLOAK_METADATA_URL"]).scheme,
-            urlparse(app.config["KEYCLOAK_METADATA_URL"]).hostname,
+            urlparse(app.config["KEYCLOAK_METADATA_URL"]).netloc,
             "/realms/master/protocol/openid-connect/token",
             "",
             "",
@@ -447,7 +447,7 @@ def get_realms() -> List[Dict[str, Any]]:
         url=urlunparse(
             (
                 urlparse(app.config["KEYCLOAK_METADATA_URL"]).scheme,
-                urlparse(app.config["KEYCLOAK_METADATA_URL"]).hostname,
+                urlparse(app.config["KEYCLOAK_METADATA_URL"]).netloc,
                 "/admin/realms",
                 "",
                 "",
@@ -513,7 +513,7 @@ def get_actor(**kwargs: str) -> Dict[str, Union[str, None]]:
                     url=urlunparse(
                         (
                             urlparse(app.config["KEYCLOAK_METADATA_URL"]).scheme,
-                            urlparse(app.config["KEYCLOAK_METADATA_URL"]).hostname,
+                            urlparse(app.config["KEYCLOAK_METADATA_URL"]).netloc,
                             "/admin/realms/" + realm["realm"] + "/users/" + kwargs["userId"],
                             "",
                             "",
@@ -539,7 +539,7 @@ def get_actor(**kwargs: str) -> Dict[str, Union[str, None]]:
                     "actorLink": urlunparse(
                         (
                             urlparse(app.config["KEYCLOAK_METADATA_URL"]).scheme,
-                            urlparse(app.config["KEYCLOAK_METADATA_URL"]).hostname,
+                            urlparse(app.config["KEYCLOAK_METADATA_URL"]).netloc,
                             "/admin/master/console/",
                             "",
                             "",
@@ -624,7 +624,7 @@ def get_client_display_name(**kwargs: str) -> str:
                     url=urlunparse(
                         (
                             urlparse(app.config["KEYCLOAK_METADATA_URL"]).scheme,
-                            urlparse(app.config["KEYCLOAK_METADATA_URL"]).hostname,
+                            urlparse(app.config["KEYCLOAK_METADATA_URL"]).netloc,
                             "/admin/realms/" + realm["realm"] + "/clients/" + kwargs["clientId"],
                             "",
                             "",
@@ -650,7 +650,7 @@ def search_keycloak(**kwargs: Union[str, bool]) -> List[Dict[str, Any]]:
         url=urlunparse(
             (
                 urlparse(app.config["KEYCLOAK_METADATA_URL"]).scheme,
-                urlparse(app.config["KEYCLOAK_METADATA_URL"]).hostname,
+                urlparse(app.config["KEYCLOAK_METADATA_URL"]).netloc,
                 "/admin/realms/" + app.config["KEYCLOAK_REALM"] + "/users",
                 "",
                 "",
@@ -1110,7 +1110,7 @@ def format_search_result_blocks(
                     "url": urlunparse(
                         (
                             urlparse(app.config["KEYCLOAK_METADATA_URL"]).scheme,
-                            urlparse(app.config["KEYCLOAK_METADATA_URL"]).hostname,
+                            urlparse(app.config["KEYCLOAK_METADATA_URL"]).netloc,
                             "/admin/master/console/",
                             "",
                             "",
@@ -1268,7 +1268,7 @@ def spa(directory_id: Union[str, None] = None) -> Any:  # pylint: disable=unused
                 keycloak_user_deep_link=urlunparse(
                     (
                         urlparse(app.config["KEYCLOAK_METADATA_URL"]).scheme,
-                        urlparse(app.config["KEYCLOAK_METADATA_URL"]).hostname,
+                        urlparse(app.config["KEYCLOAK_METADATA_URL"]).netloc,
                         "/admin/master/console/",
                         "",
                         "",
@@ -1288,7 +1288,7 @@ def spa(directory_id: Union[str, None] = None) -> Any:  # pylint: disable=unused
             "keycloakDeepLinkBaseUrl": urlunparse(
                 (
                     urlparse(app.config["KEYCLOAK_METADATA_URL"]).scheme,
-                    urlparse(app.config["KEYCLOAK_METADATA_URL"]).hostname,
+                    urlparse(app.config["KEYCLOAK_METADATA_URL"]).netloc,
                     "/admin/master/console/",
                     "",
                     "",
@@ -1788,7 +1788,7 @@ def get_keycloak_account(directory_id: str, is_frontend_request: bool = True) ->
             url=urlunparse(
                 (
                     urlparse(app.config["KEYCLOAK_METADATA_URL"]).scheme,
-                    urlparse(app.config["KEYCLOAK_METADATA_URL"]).hostname,
+                    urlparse(app.config["KEYCLOAK_METADATA_URL"]).netloc,
                     "/admin/realms/" + app.config["KEYCLOAK_REALM"] + "/users/" + row[0],
                     "",
                     "",
@@ -1939,7 +1939,7 @@ def get_events(directory_id: str) -> List[Dict[str, Any]]:
             url=urlunparse(
                 (
                     urlparse(app.config["KEYCLOAK_METADATA_URL"]).scheme,
-                    urlparse(app.config["KEYCLOAK_METADATA_URL"]).hostname,
+                    urlparse(app.config["KEYCLOAK_METADATA_URL"]).netloc,
                     "/admin/realms/" + app.config["KEYCLOAK_REALM"] + "/events",
                     "",
                     "",
@@ -1966,7 +1966,7 @@ def get_events(directory_id: str) -> List[Dict[str, Any]]:
                     "eventLink": urlunparse(
                         (
                             urlparse(app.config["KEYCLOAK_METADATA_URL"]).scheme,
-                            urlparse(app.config["KEYCLOAK_METADATA_URL"]).hostname,
+                            urlparse(app.config["KEYCLOAK_METADATA_URL"]).netloc,
                             "/admin/master/console/",
                             "",
                             "",
@@ -1985,7 +1985,7 @@ def get_events(directory_id: str) -> List[Dict[str, Any]]:
             url=urlunparse(
                 (
                     urlparse(app.config["KEYCLOAK_METADATA_URL"]).scheme,
-                    urlparse(app.config["KEYCLOAK_METADATA_URL"]).hostname,
+                    urlparse(app.config["KEYCLOAK_METADATA_URL"]).netloc,
                     "/admin/realms/" + app.config["KEYCLOAK_REALM"] + "/admin-events",
                     "",
                     "",
@@ -2054,7 +2054,7 @@ def get_events(directory_id: str) -> List[Dict[str, Any]]:
                     "eventLink": urlunparse(
                         (
                             urlparse(app.config["KEYCLOAK_METADATA_URL"]).scheme,
-                            urlparse(app.config["KEYCLOAK_METADATA_URL"]).hostname,
+                            urlparse(app.config["KEYCLOAK_METADATA_URL"]).netloc,
                             "/admin/master/console/",
                             "",
                             "",
@@ -3698,7 +3698,7 @@ def slack_user_has_access(user_id: str) -> bool:
         url=urlunparse(
             (
                 urlparse(app.config["KEYCLOAK_METADATA_URL"]).scheme,
-                urlparse(app.config["KEYCLOAK_METADATA_URL"]).hostname,
+                urlparse(app.config["KEYCLOAK_METADATA_URL"]).netloc,
                 "/admin/realms/"
                 + app.config["KEYCLOAK_REALM"]
                 + "/users/"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

**Code fix:** Replace all 15 uses of `urlparse(KEYCLOAK_METADATA_URL).hostname` with `.netloc` in `checkpoint.py` so that non-standard ports (e.g. `:8080`) are preserved when constructing Keycloak admin API and OIDC URLs.

**Docs:** Update `AGENTS.md` with comprehensive local development setup instructions including local Keycloak via Docker, Flask startup command, and environment notes.

## Problem

Previously, `checkpoint.py` used `urlparse(...).hostname` to extract the Keycloak host from the metadata URL. This property strips the port number, making it impossible to run Keycloak on any port other than 80 (HTTP) or 443 (HTTPS).

## Fix

Replaced `.hostname` with `.netloc` across all 15 occurrences. `urlparse().netloc` preserves the full `host:port` when a port is specified, and behaves identically to `.hostname` when no port is present in the URL.

## Testing

Full OAuth login flow verified with Keycloak running on port 8080:

<a href="https://cursor.com/agents/bc-cd7079ea-1f39-4087-89b1-22dbb5604061/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcheckpoint_login_keycloak_port_8080.mp4"><img src="https://cursor.com/artifacts/c/art-f17fb11d-20c4-4d32-83f6-d3fdb2a7b70d" alt="checkpoint_login_keycloak_port_8080.mp4" /></a>

![Keycloak login page showing port 8080 in URL bar](https://cursor.com/artifacts/c/art-95689722-5639-4895-85f9-0b8e6ebd16d5)

![Checkpoint authenticated page after login via port 8080](https://cursor.com/artifacts/c/art-73305c12-7255-4fe0-82e0-cfe3b4a84ced)

All linters pass:
- `poetry run black --check checkpoint.py` ✅
- `poetry run flake8 checkpoint.py` ✅
- `poetry run pylint checkpoint.py` ✅ (10.00/10)
- `poetry run mypy --strict --scripts-are-modules checkpoint.py` ✅
- `npm run build` (elm-review + elm-format + elm make + terser) ✅

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cd7079ea-1f39-4087-89b1-22dbb5604061"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cd7079ea-1f39-4087-89b1-22dbb5604061"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

