### PR TITLE
Add configurable Grouper base URL and mock Grouper service

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,6 +127,20 @@ poetry run flask run --no-debugger --port 5000
 
 A test user is pre-created in local Keycloak: `testuser` / `testpass123`.
 
+### Mock Grouper Service
+
+The app depends on Georgia Tech's Grouper (`grouper.gatech.edu`) which is unreachable from the cloud VM. A mock is provided in `grouper_mock.py`. Start it before Flask:
+
+```sh
+poetry run flask --app grouper_mock:mock_app run --port 9090
+```
+
+Then pass `FLASK_GROUPER_BASE_URL="http://localhost:9090"` (along with any dummy values for `FLASK_GROUPER_USERNAME` and `FLASK_GROUPER_PASSWORD`) when starting the main Flask app.
+
+### Keycloak Access Role
+
+To get past the "access denied" page, the logged-in user needs a **client role** named `access` on the `checkpoint` client in the `robojackets` realm. A protocol mapper named `checkpoint-roles` (type `oidc-usermodel-client-role-mapper`) must also exist on that client to include the role in the `roles` claim of the ID token. See the Keycloak setup steps above for the full configuration.
+
 ### Gotchas
 
 - `uwsgi` requires `python3-dev` and `build-essential` system packages to compile.

--- a/checkpoint.py
+++ b/checkpoint.py
@@ -192,7 +192,7 @@ def get_grouper_groups() -> List[str]:
     Fetch all Grouper groups under gt:services:robojackets and return extension names
     """
     response = post(
-        url="https://grouper.gatech.edu/grouper-ws/servicesRest/v4_0_000/groups",
+        url=app.config["GROUPER_BASE_URL"] + "/grouper-ws/servicesRest/v4_0_000/groups",
         auth=(app.config["GROUPER_USERNAME"], app.config["GROUPER_PASSWORD"]),
         headers={
             "User-Agent": USER_AGENT,
@@ -1165,7 +1165,8 @@ def format_search_result_blocks(
                             },
                             {
                                 "text": {"type": "plain_text", "text": "View in Grouper"},
-                                "url": "https://grouper.gatech.edu/grouper/grouperUi/app/UiV2Main.index?operation=UiV2Subject.viewSubject&subjectId="  # noqa
+                                "url": app.config["GROUPER_BASE_URL"]
+                                + "/grouper/grouperUi/app/UiV2Main.index?operation=UiV2Subject.viewSubject&subjectId="  # noqa
                                 + primary_username
                                 + "&sourceId=gted-accounts",
                             },
@@ -3578,7 +3579,8 @@ def get_grouper_memberships(directory_id: str) -> Dict[str, Any]:
         primary_username = gted_account["gtPrimaryGTAccountUsername"]
 
     grouper_response = get(
-        url="https://grouper.gatech.edu/grouper-ws/servicesRest/v4_0_000/subjects/"
+        url=app.config["GROUPER_BASE_URL"]
+        + "/grouper-ws/servicesRest/v4_0_000/subjects/"
         + primary_username
         + "/memberships",
         auth=(app.config["GROUPER_USERNAME"], app.config["GROUPER_PASSWORD"]),

--- a/grouper_mock.py
+++ b/grouper_mock.py
@@ -1,0 +1,90 @@
+"""
+Mock Grouper web service for local development.
+
+Exposes the same REST endpoints that checkpoint.py calls on the real
+grouper.gatech.edu so that the application can start and serve the
+search page without network connectivity to Georgia Tech.
+
+Run standalone:
+    poetry run flask --app grouper_mock run --port 9090
+
+Endpoints:
+    POST /grouper-ws/servicesRest/v4_0_000/groups
+    GET  /grouper-ws/servicesRest/v4_0_000/subjects/<subject_id>/memberships
+"""
+
+from flask import Flask, jsonify, request
+from typing import Any, Dict
+
+mock_app = Flask(__name__)
+
+MOCK_GROUPS = [
+    "general",
+    "core",
+    "it",
+    "battlebots",
+    "robocup",
+    "robonav",
+    "roboracing",
+    "robowrestling",
+]
+
+MOCK_MEMBERSHIPS: Dict[str, Any] = {
+    "wsMemberships": [
+        {
+            "subjectId": "testuser",
+            "groupName": "gt:services:robojackets:general",
+            "createTime": "2024/01/15 10:30:00.000",
+        },
+        {
+            "subjectId": "testuser",
+            "groupName": "gt:services:robojackets:core",
+            "createTime": "2024/02/01 14:00:00.000",
+        },
+    ],
+    "wsGroups": [
+        {"extension": "general"},
+        {"extension": "core"},
+    ],
+}
+
+
+@mock_app.post("/grouper-ws/servicesRest/v4_0_000/groups")
+def find_groups() -> Any:
+    return jsonify(
+        {
+            "WsFindGroupsResults": {
+                "groupResults": [
+                    {
+                        "extension": group,
+                        "name": f"gt:services:robojackets:{group}",
+                        "displayName": f"gt:services:robojackets:{group}",
+                    }
+                    for group in MOCK_GROUPS
+                ]
+            }
+        }
+    )
+
+
+@mock_app.get(
+    "/grouper-ws/servicesRest/v4_0_000/subjects/<subject_id>/memberships"
+)
+def get_memberships(subject_id: str) -> Any:
+    memberships = {
+        "wsMemberships": [
+            {**m, "subjectId": subject_id}
+            for m in (MOCK_MEMBERSHIPS.get("wsMemberships") or [])
+        ],
+        "wsGroups": MOCK_MEMBERSHIPS.get("wsGroups", []),
+    }
+    return jsonify({"WsGetMembershipsResults": memberships})
+
+
+@mock_app.get("/grouper-ws/healthcheck")
+def healthcheck() -> Any:
+    return jsonify({"status": "ok"})
+
+
+if __name__ == "__main__":
+    mock_app.run(port=9090)

--- a/grouper_mock.py
+++ b/grouper_mock.py
@@ -13,7 +13,7 @@ Endpoints:
     GET  /grouper-ws/servicesRest/v4_0_000/subjects/<subject_id>/memberships
 """
 
-from flask import Flask, jsonify, request
+from flask import Flask, jsonify
 from typing import Any, Dict
 
 mock_app = Flask(__name__)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This PR makes the Grouper service dependency configurable and adds a mock service for local/cloud development where `grouper.gatech.edu` is unreachable.

### Changes

**`checkpoint.py`** — Replace all three hardcoded `https://grouper.gatech.edu` URLs with `app.config["GROUPER_BASE_URL"]`:
- `get_grouper_groups()` — find-groups POST endpoint
- `get_grouper_memberships()` — subject memberships GET endpoint  
- Slack overflow menu "View in Grouper" link

The base URL is configured via `FLASK_GROUPER_BASE_URL` env var (same pattern as `FLASK_APIARY_BASE_URL` and `FLASK_KEYCLOAK_METADATA_URL`).

**`grouper_mock.py`** — New standalone Flask app exposing the same Grouper REST endpoints:
- `POST /grouper-ws/servicesRest/v4_0_000/groups` — returns mock RoboJackets groups
- `GET /grouper-ws/servicesRest/v4_0_000/subjects/<id>/memberships` — returns mock memberships
- `GET /grouper-ws/healthcheck` — health check endpoint

Run with: `poetry run flask --app grouper_mock:mock_app run --port 9090`

**`AGENTS.md`** — Documented mock Grouper setup and Keycloak access role configuration.

### Testing

![Search page with search bar](https://cursor.com/artifacts/c/art-06e87ba0-74c7-4ddb-9086-df37d571e048)

Search page loads with search bar after configuring the access role and mock Grouper.

<a href="https://cursor.com/agents/bc-81fcf8e7-2823-42ab-9665-99ce661891f2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdemo_search_page_with_access.mp4"><img src="https://cursor.com/artifacts/c/art-ff0cd599-3eba-435a-a296-d6f566a1f1f7" alt="demo_search_page_with_access.mp4" /></a>

- All Python linters pass (black, flake8, pylint 10/10, mypy)
- Elm frontend build passes (elm-review, elm-format, elm make, terser)
- Flask app starts with mock Grouper and serves the search page
- Keycloak OIDC login flow works end-to-end with access role
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-81fcf8e7-2823-42ab-9665-99ce661891f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-81fcf8e7-2823-42ab-9665-99ce661891f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

