### PR TITLE
Add mock LDAP server and make LDAP hostnames configurable

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -3,3 +3,4 @@ max-line-length = 100
 
 per-file-ignores =
     grouper_mock.py:E501
+    ldap_mock.py:E203

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,7 +110,7 @@ The Apiary service (`https://my.robojackets.org`) is an external production API 
 
 ### Starting the Flask App (Cloud Dev)
 
-After Docker/Keycloak are running and Apiary is accessible:
+After Docker/Keycloak are running, Apiary is accessible, and the mock services are started:
 
 ```sh
 FLASK_APP=checkpoint.py \
@@ -124,6 +124,15 @@ FLASK_KEYCLOAK_REALM="robojackets" \
 FLASK_CACHE_TYPE="SimpleCache" \
 FLASK_DEBUG="1" \
 FLASK_DATABASE_LOCATION="/tmp/checkpoint.db" \
+FLASK_GROUPER_BASE_URL="http://localhost:9090" \
+FLASK_GROUPER_USERNAME="dummy" \
+FLASK_GROUPER_PASSWORD="dummy" \
+FLASK_WHITEPAGES_HOST="localhost" \
+FLASK_WHITEPAGES_PORT="10389" \
+FLASK_GTAD_HOST="localhost" \
+FLASK_GTAD_PORT="10389" \
+FLASK_GTAD_BIND_DN="cn=admin,dc=ad,dc=gatech,dc=edu" \
+FLASK_GTAD_BIND_PASSWORD="dummy" \
 poetry run flask run --no-debugger --port 5000
 ```
 
@@ -140,6 +149,21 @@ poetry run flask --app grouper_mock:mock_app run --port 9090
 ```
 
 Then pass `FLASK_GROUPER_BASE_URL="http://localhost:9090"` (along with any dummy values for `FLASK_GROUPER_USERNAME` and `FLASK_GROUPER_PASSWORD`) when starting the main Flask app.
+
+### Mock LDAP Service (Whitepages + GTAD)
+
+The app depends on two Georgia Tech LDAP services — Whitepages (`whitepages.gatech.edu`) and GTAD (`campusad.ad.gatech.edu`) — both unreachable from the cloud VM. A mock LDAP server is provided in `ldap_mock.py`. Start it before Flask:
+
+```sh
+poetry run python ldap_mock.py --port 10389
+```
+
+Then pass these env vars when starting the main Flask app:
+- `FLASK_WHITEPAGES_HOST="localhost"` and `FLASK_WHITEPAGES_PORT="10389"`
+- `FLASK_GTAD_HOST="localhost"` and `FLASK_GTAD_PORT="10389"`
+- `FLASK_GTAD_BIND_DN="cn=admin,dc=ad,dc=gatech,dc=edu"` and `FLASK_GTAD_BIND_PASSWORD="dummy"`
+
+The mock returns empty results for all LDAP searches. In the UI, the Whitepages card shows "No entries" and the GTAD card renders without data (empty state). The `WHITEPAGES_HOST`, `WHITEPAGES_PORT`, `GTAD_HOST`, and `GTAD_PORT` config values default to the production hostnames and standard LDAP port when not set.
 
 ### Keycloak Access Role
 

--- a/checkpoint.py
+++ b/checkpoint.py
@@ -341,9 +341,15 @@ def search_whitepages(**kwargs: str) -> List[Dict[str, Dict[str, List[str]]]]:
     """
     Search Whitepages with a given LDAP filter
     """
+    whitepages_port = app.config.get("WHITEPAGES_PORT")
+
     with sentry_sdk.start_span(op="whitepages.connect"):
         whitepages = Connection(
-            Server("whitepages.gatech.edu", connect_timeout=1),
+            Server(
+                app.config.get("WHITEPAGES_HOST", "whitepages.gatech.edu"),
+                port=int(whitepages_port) if whitepages_port is not None else None,
+                connect_timeout=1,
+            ),
             auto_bind=True,
             raise_exceptions=True,
             receive_timeout=1,
@@ -411,9 +417,15 @@ def search_gtad(uid: str) -> Union[Dict[str, List[str]], None]:
     """
     Look up an account in GTAD by uid and return its title/department attributes
     """
+    gtad_port = app.config.get("GTAD_PORT")
+
     with sentry_sdk.start_span(op="gtad.connect"):
         ldap = Connection(
-            Server("campusad.ad.gatech.edu", connect_timeout=1),
+            Server(
+                app.config.get("GTAD_HOST", "campusad.ad.gatech.edu"),
+                port=int(gtad_port) if gtad_port is not None else None,
+                connect_timeout=1,
+            ),
             user=app.config["GTAD_BIND_DN"],
             password=app.config["GTAD_BIND_PASSWORD"],
             auto_bind=True,
@@ -1744,8 +1756,14 @@ def get_gtad_account(directory_id: str) -> Any:
 
         primary_username = gted_account["gtPrimaryGTAccountUsername"]
 
+    gtad_port = app.config.get("GTAD_PORT")
+
     ldap = Connection(
-        Server("campusad.ad.gatech.edu", connect_timeout=1),
+        Server(
+            app.config.get("GTAD_HOST", "campusad.ad.gatech.edu"),
+            port=int(gtad_port) if gtad_port is not None else None,
+            connect_timeout=1,
+        ),
         user=app.config["GTAD_BIND_DN"],
         password=app.config["GTAD_BIND_PASSWORD"],
         auto_bind=True,

--- a/ldap_mock.py
+++ b/ldap_mock.py
@@ -1,0 +1,233 @@
+"""
+Mock LDAP server for local development.
+
+Speaks just enough of the LDAP wire protocol (RFC 4511, BER-encoded)
+to satisfy the ldap3 client library used by checkpoint.py. Returns
+empty search results for every query so the application can start
+without connectivity to Whitepages or GTAD.
+
+Run standalone:
+    poetry run python ldap_mock.py [--port PORT]
+
+Serves both anonymous binds (Whitepages) and simple authenticated
+binds (GTAD) on the same port.
+"""
+
+import argparse
+import logging
+import socket
+import threading
+from typing import Tuple
+
+logging.basicConfig(level=logging.DEBUG)
+logger = logging.getLogger("ldap_mock")
+
+# ---------------------------------------------------------------------------
+# Minimal BER / LDAP helpers
+# ---------------------------------------------------------------------------
+
+# LDAP protocol tags (application class, constructed where noted)
+BIND_REQUEST = 0x60
+BIND_RESPONSE = 0x61
+UNBIND_REQUEST = 0x42
+SEARCH_REQUEST = 0x63
+SEARCH_RESULT_DONE = 0x65
+EXTENDED_REQUEST = 0x77
+EXTENDED_RESPONSE = 0x78
+
+
+def ber_read_tag_length(data: bytes, offset: int) -> Tuple[int, int, int]:
+    """Return (tag, length, new_offset) for one BER TLV at *offset*."""
+    if offset >= len(data):
+        raise ValueError("no data")
+    tag = data[offset]
+    offset += 1
+
+    if offset >= len(data):
+        raise ValueError("truncated length")
+
+    first = data[offset]
+    offset += 1
+    if first < 0x80:
+        length = first
+    elif first == 0x80:
+        raise ValueError("indefinite length not supported")
+    else:
+        num_bytes = first & 0x7F
+        if offset + num_bytes > len(data):
+            raise ValueError("truncated long length")
+        length = int.from_bytes(data[offset : offset + num_bytes], "big")
+        offset += num_bytes
+    return tag, length, offset
+
+
+def ber_encode_length(length: int) -> bytes:
+    """Encode a BER length field."""
+    if length < 0x80:
+        return bytes([length])
+    encoded = length.to_bytes((length.bit_length() + 7) // 8, "big")
+    return bytes([0x80 | len(encoded)]) + encoded
+
+
+def ber_encode_integer(value: int) -> bytes:
+    """Encode a BER INTEGER."""
+    if value == 0:
+        payload = b"\x00"
+    else:
+        byte_len = (value.bit_length() + 8) // 8
+        payload = value.to_bytes(byte_len, "big", signed=True)
+    return b"\x02" + ber_encode_length(len(payload)) + payload
+
+
+def ber_encode_octet_string(value: bytes) -> bytes:
+    """Encode a BER OCTET STRING."""
+    return b"\x04" + ber_encode_length(len(value)) + value
+
+
+def ber_encode_enum(value: int) -> bytes:
+    """Encode a BER ENUMERATED value."""
+    payload = value.to_bytes(1, "big")
+    return b"\x0a" + ber_encode_length(len(payload)) + payload
+
+
+def ber_encode_sequence(payload: bytes) -> bytes:
+    """Encode a BER SEQUENCE."""
+    return b"\x30" + ber_encode_length(len(payload)) + payload
+
+
+def ber_build_ldap_message(message_id: int, op_tag: int, op_payload: bytes) -> bytes:
+    """Wrap an LDAP operation in a top-level LDAPMessage SEQUENCE."""
+    inner = ber_encode_integer(message_id)
+    inner += bytes([op_tag]) + ber_encode_length(len(op_payload)) + op_payload
+    return ber_encode_sequence(inner)
+
+
+def ber_read_integer(data: bytes, offset: int) -> Tuple[int, int]:
+    """Read a BER INTEGER, return (value, new_offset)."""
+    tag, length, offset = ber_read_tag_length(data, offset)
+    if tag != 0x02:
+        raise ValueError(f"expected INTEGER (0x02), got 0x{tag:02x}")
+    value = int.from_bytes(data[offset : offset + length], "big", signed=True)
+    return value, offset + length
+
+
+# ---------------------------------------------------------------------------
+# LDAP response builders
+# ---------------------------------------------------------------------------
+
+RESULT_SUCCESS = 0
+
+
+def ldap_result_payload(
+    result_code: int = RESULT_SUCCESS,
+    matched_dn: bytes = b"",
+    diagnostic: bytes = b"",
+) -> bytes:
+    """Encode the common LDAPResult fields."""
+    return (
+        ber_encode_enum(result_code)
+        + ber_encode_octet_string(matched_dn)
+        + ber_encode_octet_string(diagnostic)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Connection handler
+# ---------------------------------------------------------------------------
+
+
+def recvall(sock: socket.socket, n: int) -> bytes:
+    """Receive exactly *n* bytes or raise."""
+    buf = bytearray()
+    while len(buf) < n:
+        chunk = sock.recv(n - len(buf))
+        if not chunk:
+            raise ConnectionError("client closed")
+        buf.extend(chunk)
+    return bytes(buf)
+
+
+def read_ldap_message(sock: socket.socket) -> bytes:
+    """Read one complete BER-encoded LDAP message from the socket."""
+    header = recvall(sock, 2)
+    if header[0] != 0x30:
+        raise ValueError(f"expected SEQUENCE tag 0x30, got 0x{header[0]:02x}")
+
+    first = header[1]
+    if first < 0x80:
+        length = first
+    elif first == 0x80:
+        raise ValueError("indefinite length not supported")
+    else:
+        num_bytes = first & 0x7F
+        length_bytes = recvall(sock, num_bytes)
+        length = int.from_bytes(length_bytes, "big")
+        header = header + length_bytes
+
+    body = recvall(sock, length)
+    return header + body
+
+
+def handle_client(conn: socket.socket, addr: Tuple[str, int]) -> None:
+    """Handle one LDAP client connection."""
+    logger.info("connection from %s", addr)
+    try:
+        while True:
+            try:
+                raw = read_ldap_message(conn)
+            except (ConnectionError, ValueError):
+                break
+
+            _, _, offset = ber_read_tag_length(raw, 0)
+            message_id, offset = ber_read_integer(raw, offset)
+
+            op_tag = raw[offset]
+            _, op_len, _ = ber_read_tag_length(raw, offset)
+
+            logger.debug("msg %d  op=0x%02x  len=%d", message_id, op_tag, op_len)
+
+            if op_tag == BIND_REQUEST:
+                resp = ber_build_ldap_message(message_id, BIND_RESPONSE, ldap_result_payload())
+                conn.sendall(resp)
+
+            elif op_tag == SEARCH_REQUEST:
+                resp = ber_build_ldap_message(message_id, SEARCH_RESULT_DONE, ldap_result_payload())
+                conn.sendall(resp)
+
+            elif op_tag == UNBIND_REQUEST:
+                break
+
+            elif op_tag == EXTENDED_REQUEST:
+                resp = ber_build_ldap_message(message_id, EXTENDED_RESPONSE, ldap_result_payload())
+                conn.sendall(resp)
+
+            else:
+                logger.warning("unhandled op 0x%02x – ignoring", op_tag)
+    finally:
+        conn.close()
+        logger.info("closed %s", addr)
+
+
+# ---------------------------------------------------------------------------
+# Server entry point
+# ---------------------------------------------------------------------------
+
+
+def serve(host: str = "127.0.0.1", port: int = 10389) -> None:
+    """Run the mock LDAP server."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as srv:
+        srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        srv.bind((host, port))
+        srv.listen(8)
+        logger.info("mock LDAP listening on %s:%d", host, port)
+        while True:
+            client, addr = srv.accept()
+            threading.Thread(target=handle_client, args=(client, addr), daemon=True).start()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Mock LDAP server")
+    parser.add_argument("--port", type=int, default=10389)
+    parser.add_argument("--host", type=str, default="127.0.0.1")
+    args = parser.parse_args()
+    serve(host=args.host, port=args.port)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "checkpoint",
+  "name": "workspace",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This PR adds a mock LDAP service for local/cloud development and makes the hardcoded LDAP hostnames configurable, enabling the application to run without connectivity to Georgia Tech's Whitepages and GTAD servers.

### Changes

**New file: `ldap_mock.py`**
- Minimal LDAP server (~230 lines) that speaks the LDAP wire protocol (BER-encoded, per RFC 4511)
- Handles Bind Requests (both anonymous for Whitepages and authenticated for GTAD) and Search Requests
- Returns empty results for all searches, matching the "no data available" scenario
- Runs on a configurable port (default 10389) and serves both services on the same port

**Modified: `checkpoint.py`**
- Extracted hardcoded LDAP hostnames into configurable settings:
  - `WHITEPAGES_HOST` / `WHITEPAGES_PORT` (defaults to `whitepages.gatech.edu` / standard LDAP port)
  - `GTAD_HOST` / `GTAD_PORT` (defaults to `campusad.ad.gatech.edu` / standard LDAP port)
- Applied to all three LDAP connection sites: `search_whitepages()`, `search_gtad()`, and `get_gtad_account()`
- Port values are safely converted from string (env var) to int, with `None` fallback for production defaults

**Modified: `.flake8`**
- Added E203 ignore for `ldap_mock.py` (black/flake8 slice formatting conflict)

**Modified: `AGENTS.md`**
- Added mock LDAP service documentation and updated Flask startup command with all LDAP env vars

### How to use

Start the mock LDAP server before Flask:
```sh
poetry run python ldap_mock.py --port 10389
```

Then pass these env vars when starting Flask:
```
FLASK_WHITEPAGES_HOST="localhost"
FLASK_WHITEPAGES_PORT="10389"
FLASK_GTAD_HOST="localhost"
FLASK_GTAD_PORT="10389"
FLASK_GTAD_BIND_DN="cn=admin,dc=ad,dc=gatech,dc=edu"
FLASK_GTAD_BIND_PASSWORD="dummy"
```

### Testing

Validated by searching "kristaps berzinch" in the UI:
- Search results render correctly
- Whitepages card shows "No entries"
- GTAD card renders in empty state (no data)

All linters pass: `black`, `flake8`, `pylint` (10.00/10), `mypy` (strict).

### Demo

<a href="https://cursor.com/agents/bc-e7e26e49-d36c-4391-8973-32b4623e2ad0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdemo_search_kristaps_berzinch.mp4"><img src="https://cursor.com/artifacts/c/art-3fc4c001-c3de-4f22-b922-5075a82acd9a" alt="demo_search_kristaps_berzinch.mp4" /></a>

Search results and detail view with Whitepages "No entries":

![Detail view showing Whitepages No entries and GTAD cards](https://cursor.com/artifacts/c/art-3c001e1a-c45e-4cd3-94d0-4b1f5de1d4f0)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e7e26e49-d36c-4391-8973-32b4623e2ad0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e7e26e49-d36c-4391-8973-32b4623e2ad0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

