### PR TITLE
Display Keycloak logout events correctly in event log

### DIFF
--- a/checkpoint.py
+++ b/checkpoint.py
@@ -1987,8 +1987,8 @@ def get_events(directory_id: str) -> List[Dict[str, Any]]:
             elif event["type"] == "LOGOUT_ERROR":
                 description = "failed to log out of " + client_id
             else:
-                print(dumps(event))
-                raise InternalServerError("Unrecognized type in Keycloak event: " + event["type"])
+                # Skip unrecognized event types (e.g. CODE_TO_TOKEN)
+                continue
 
             events.append(
                 {

--- a/checkpoint.py
+++ b/checkpoint.py
@@ -1978,10 +1978,22 @@ def get_events(directory_id: str) -> List[Dict[str, Any]]:
             else:
                 client_id = event["clientId"]
 
+            if event["type"] == "LOGIN":
+                description = "logged into " + client_id
+            elif event["type"] == "LOGOUT":
+                description = "logged out of " + client_id
+            elif event["type"] == "LOGIN_ERROR":
+                description = "failed to log into " + client_id
+            elif event["type"] == "LOGOUT_ERROR":
+                description = "failed to log out of " + client_id
+            else:
+                print(dumps(event))
+                raise InternalServerError("Unrecognized type in Keycloak event: " + event["type"])
+
             events.append(
                 {
                     "eventTimestamp": event["time"],
-                    "eventDescription": "logged into " + client_id,
+                    "eventDescription": description,
                     "eventLink": urlunparse(
                         (
                             urlparse(app.config["KEYCLOAK_METADATA_URL"]).scheme,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #4.

The event log used to render every Keycloak user event as `"logged into {client}"`. Keycloak's `/admin/realms/{realm}/events` endpoint actually returns multiple event types on its `type` field, so logouts and login errors were being mislabelled as logins.

`get_events` now switches on `event["type"]`:

| `type`         | description                       |
|----------------|-----------------------------------|
| `LOGIN`        | `logged into {client}`            |
| `LOGOUT`       | `logged out of {client}`          |
| `LOGIN_ERROR`  | `failed to log into {client}`     |
| `LOGOUT_ERROR` | `failed to log out of {client}`   |

Any other user event type (e.g. `CODE_TO_TOKEN`, which Keycloak emits on every authorization-code exchange and which a real Keycloak event log will always contain) is silently skipped so the event panel keeps loading instead of returning a 500.

### Testing

Local Keycloak + mock services. `kberzinch3` (real GTED user, directory id `983D874CDD2041E4E6E3F1ABB3821058`) was created in the local realm, then driven through password-grant logins, an OIDC logout, and a wrong-password attempt to populate `LOGIN`, `LOGOUT`, and `LOGIN_ERROR` events.

Endpoint output before the fix (`git checkout main -- checkpoint.py`):

```
- logged into checkpoint
- logged into checkpoint   <- actually a LOGOUT
- logged into checkpoint   <- actually a LOGIN_ERROR
- logged into checkpoint
```

After the fix:

```
- failed to log into checkpoint
- logged into checkpoint
- logged out of checkpoint
- logged into checkpoint
```

UI walkthrough confirms the events panel renders correctly when logged in as `kberzinch3` and viewing his own profile:

![Events panel showing distinct logged into / logged out of / failed to log into entries](https://cursor.com/artifacts/c/art-9524ee1f-b89f-43f4-9f35-8e2a50419aae)

### Linters

- ✅ `poetry run black --check checkpoint.py`
- ✅ `poetry run flake8 checkpoint.py`
- ✅ `poetry run pylint checkpoint.py` (10.00/10)
- ✅ `poetry run mypy --strict --scripts-are-modules checkpoint.py`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-22a1e2c3-21e9-4ad1-8edf-88f04d4d333a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-22a1e2c3-21e9-4ad1-8edf-88f04d4d333a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

