### PR TITLE
Apply UI style guide to loading and empty states

### DIFF
--- a/elm/Main.elm
+++ b/elm/Main.elm
@@ -984,10 +984,10 @@ searchResultPlaceholder =
     div [ class "mb-4" ]
         [ h4 [ class "mb-1", class "placeholder-wave" ] [ span [ class "placeholder", class "col-2", class "me-1" ] [], span [ class "placeholder", class "col-3" ] [] ]
         , div [ class "mb-1", class "placeholder-wave" ] [ span [ class "placeholder", class "col-1", class "me-1" ] [], span [ class "placeholder", class "col-2" ] [] ]
-        , span [ class "rounded-pill", class "me-1", class "placeholder", class "placeholder-wave", class "col-1" ] []
-        , span [ class "rounded-pill", class "me-1", class "placeholder", class "placeholder-wave", class "col-1" ] []
-        , span [ class "rounded-pill", class "me-1", class "placeholder", class "placeholder-wave", class "col-1" ] []
-        , span [ class "rounded-pill", class "me-1", class "placeholder", class "placeholder-wave", class "col-1" ] []
+        , span [ class "badge", class "rounded-pill", class "me-1", class "placeholder", class "placeholder-wave", class "text-bg-secondary", class "text-secondary" ] [ text "STUDENT-UGRAD" ]
+        , span [ class "badge", class "rounded-pill", class "me-1", class "placeholder", class "placeholder-wave", class "text-bg-secondary", class "text-secondary" ] [ text "STUDENT-UGRAD" ]
+        , span [ class "badge", class "rounded-pill", class "me-1", class "placeholder", class "placeholder-wave", class "text-bg-secondary", class "text-secondary" ] [ text "STUDENT-UGRAD" ]
+        , span [ class "badge", class "rounded-pill", class "me-1", class "placeholder", class "placeholder-wave", class "text-bg-secondary", class "text-secondary" ] [ text "STUDENT-UGRAD" ]
         ]
 
 
@@ -2007,7 +2007,7 @@ viewPerson model =
                                                         Just (Ok groups) ->
                                                             case List.length groups of
                                                                 0 ->
-                                                                    [ div [] [ text "No groups" ] ]
+                                                                    [ div [ class "text-secondary" ] [ text "No groups" ] ]
 
                                                                 1 ->
                                                                     [ div [ class "mb-1" ] [ text "1 group" ] ]
@@ -2016,7 +2016,7 @@ viewPerson model =
                                                                     [ div [ class "mb-1" ] [ text (String.fromInt (List.length groups) ++ " groups") ] ]
 
                                                         Nothing ->
-                                                            [ div [ class "placeholder-wave", class "mb-1" ] [ span [ class "placeholder", class "col-1" ] [] ] ]
+                                                            [ div [ class "placeholder-wave", class "mb-1", class "text-secondary" ] [ text "Loading..." ] ]
 
                                                 Nothing ->
                                                     []
@@ -2031,7 +2031,7 @@ viewPerson model =
                                                             List.map (\groupName -> span [ class "badge", class "rounded-pill", class "text-bg-primary", class "me-1" ] [ text groupName ]) groups
 
                                                         Nothing ->
-                                                            [ div [ class "placeholder-wave" ] [ span [ class "placeholder", class "rounded-pill", class "col-1" ] [] ] ]
+                                                            [ span [ class "placeholder", class "placeholder-wave", class "badge", class "rounded-pill", class "text-bg-secondary", class "text-secondary", class "me-1" ] [ text "robowrestling" ] ]
 
                                                 Nothing ->
                                                     []
@@ -2055,7 +2055,7 @@ viewPerson model =
                                                             [ div [ class "mb-1" ] [ text "1 account" ] ]
 
                                                         Nothing ->
-                                                            [ div [ class "placeholder-wave", class "mb-1" ] [ span [ class "placeholder", class "col-1" ] [] ] ]
+                                                            [ div [ class "placeholder-wave", class "mb-1", class "text-secondary" ] [ text "Loading..." ] ]
 
                                                 Nothing ->
                                                     []
@@ -2070,7 +2070,7 @@ viewPerson model =
                                                             List.map (\groupName -> span [ class "badge", class "rounded-pill", class "text-bg-primary", class "me-1" ] [ text groupName ]) (List.sort (List.filterMap (\groupName -> Dict.get groupName groupNameMap) (Maybe.withDefault [] (Dict.get "memberOf" account.attributes))))
 
                                                         Nothing ->
-                                                            [ div [ class "placeholder-wave" ] [ span [ class "placeholder", class "rounded-pill", class "col-1" ] [] ] ]
+                                                            [ span [ class "placeholder", class "placeholder-wave", class "badge", class "rounded-pill", class "text-bg-secondary", class "text-secondary", class "me-1" ] [ text "robowrestling" ] ]
 
                                                 Nothing ->
                                                     []
@@ -2094,7 +2094,7 @@ viewPerson model =
                                                         Just (Ok entries) ->
                                                             case List.length entries of
                                                                 0 ->
-                                                                    [ div [] [ text "No accounts" ] ]
+                                                                    [ div [ class "text-secondary" ] [ text "No accounts" ] ]
 
                                                                 1 ->
                                                                     [ div [ class "mb-1" ] [ text "1 account" ] ]
@@ -2103,7 +2103,7 @@ viewPerson model =
                                                                     [ div [ class "mb-1" ] [ text (String.fromInt (List.length entries) ++ " accounts") ] ]
 
                                                         Nothing ->
-                                                            [ div [ class "placeholder-wave", class "mb-1" ] [ span [ class "placeholder", class "col-1" ] [] ] ]
+                                                            [ div [ class "placeholder-wave", class "mb-1", class "text-secondary" ] [ text "Loading..." ] ]
 
                                                 Nothing ->
                                                     []
@@ -2126,7 +2126,7 @@ viewPerson model =
                                                             ]
 
                                                         Nothing ->
-                                                            [ div [ class "placeholder-wave" ] [ span [ class "placeholder", class "rounded-pill", class "col-1" ] [] ] ]
+                                                            [ span [ class "placeholder", class "placeholder-wave", class "badge", class "rounded-pill", class "text-bg-secondary", class "text-secondary", class "me-1" ] [ text "affiliate" ] ]
 
                                                 Nothing ->
                                                     []
@@ -2151,10 +2151,10 @@ viewPerson model =
                                                             [ div [ class "mb-1" ] [ text "1 account" ] ]
 
                                                         Just (Ok Nothing) ->
-                                                            [ div [] [ text "No account" ] ]
+                                                            [ div [ class "text-secondary" ] [ text "No account" ] ]
 
                                                         Nothing ->
-                                                            [ div [ class "placeholder-wave", class "mb-1" ] [ span [ class "placeholder", class "col-1" ] [] ] ]
+                                                            [ div [ class "placeholder-wave", class "mb-1", class "text-secondary" ] [ text "Loading..." ] ]
 
                                                 Nothing ->
                                                     []
@@ -2176,7 +2176,7 @@ viewPerson model =
                                                             []
 
                                                         Nothing ->
-                                                            [ div [ class "placeholder-wave" ] [ span [ class "placeholder", class "rounded-pill", class "col-1" ] [] ] ]
+                                                            [ span [ class "placeholder", class "placeholder-wave", class "badge", class "rounded-pill", class "text-bg-secondary", class "text-secondary", class "me-1" ] [ text "disabled" ] ]
 
                                                 Nothing ->
                                                     []
@@ -2199,7 +2199,7 @@ viewPerson model =
                                                         Just (Ok entries) ->
                                                             case List.length entries of
                                                                 0 ->
-                                                                    [ div [] [ text "No entries" ] ]
+                                                                    [ div [ class "text-secondary" ] [ text "No entries" ] ]
 
                                                                 1 ->
                                                                     [ div [ class "mb-1" ] [ text "1 entry" ] ]
@@ -2208,7 +2208,7 @@ viewPerson model =
                                                                     [ div [ class "mb-1" ] [ text (String.fromInt (List.length entries) ++ " entries") ] ]
 
                                                         Nothing ->
-                                                            [ div [ class "placeholder-wave", class "mb-1" ] [ span [ class "placeholder", class "col-1" ] [] ] ]
+                                                            [ div [ class "placeholder-wave", class "mb-1", class "text-secondary" ] [ text "Loading..." ] ]
 
                                                 Nothing ->
                                                     []
@@ -2223,7 +2223,7 @@ viewPerson model =
                                                             [ div [] (List.map whitepagesEntryToEmployeeTypePill entries) ]
 
                                                         Nothing ->
-                                                            [ div [ class "placeholder-wave" ] [ span [ class "placeholder", class "rounded-pill", class "col-1" ] [] ] ]
+                                                            [ span [ class "placeholder", class "placeholder-wave", class "badge", class "rounded-pill", class "text-bg-secondary", class "text-secondary", class "me-1" ] [ text "Temporary Employee" ] ]
 
                                                 Nothing ->
                                                     []
@@ -2240,10 +2240,20 @@ viewPerson model =
                                     Just selectedUser ->
                                         case selectedUser.events of
                                             Just (Ok events) ->
-                                                List.map (eventToHtmlRow model.zone model.zoneName) (List.sortWith sortByEventTimestamp events)
+                                                if List.isEmpty events then
+                                                    [ tr [] [ td [ class "text-secondary", class "border-0" ] [ text "No events" ] ] ]
 
-                                            _ ->
+                                                else
+                                                    List.map (eventToHtmlRow model.zone model.zoneName) (List.sortWith sortByEventTimestamp events)
+
+                                            Just (Err _) ->
                                                 []
+
+                                            Nothing ->
+                                                [ eventRowPlaceholder
+                                                , eventRowPlaceholder
+                                                , eventRowPlaceholder
+                                                ]
 
                                     _ ->
                                         []
@@ -2412,6 +2422,16 @@ eventToHtmlRow zone zoneName event =
 sortByEventTimestamp : Event -> Event -> Order
 sortByEventTimestamp first second =
     compare (Time.posixToMillis second.eventTimestamp) (Time.posixToMillis first.eventTimestamp)
+
+
+eventRowPlaceholder : Html msg
+eventRowPlaceholder =
+    tr []
+        [ td [ style "width" "20%" ]
+            [ span [ class "placeholder", class "placeholder-wave", class "col-10", class "text-secondary" ] [] ]
+        , td []
+            [ span [ class "placeholder", class "placeholder-wave", class "col-7", class "text-secondary" ] [] ]
+        ]
 
 
 renderAppStatusBadge : AppStatusBadge -> Html msg
@@ -2799,7 +2819,7 @@ googleGroupsProvisioning model =
                     span [ class "text-secondary" ] [ text "Error loading Apiary account" ]
 
                 Nothing ->
-                    div [ class "mb-1", class "placeholder-wave" ] [ span [ class "placeholder", class "col-12" ] [] ]
+                    div [ class "mb-1", class "placeholder-wave", class "text-secondary" ] [ text "Loading..." ]
 
         Nothing ->
             text ""
@@ -3295,7 +3315,7 @@ sumsBillingGroupsProvisioning model =
                     [ span [ class "text-secondary" ] [ text "Error loading billing groups" ] ]
 
                 Nothing ->
-                    [ div [ class "mb-1", class "placeholder-wave" ] [ span [ class "placeholder", class "col-12" ] [] ] ]
+                    [ div [ class "mb-1", class "placeholder-wave", class "text-secondary" ] [ text "Loading..." ] ]
 
         Nothing ->
             [ text "" ]

--- a/elm/Main.elm
+++ b/elm/Main.elm
@@ -984,10 +984,9 @@ searchResultPlaceholder =
     div [ class "mb-4" ]
         [ h4 [ class "mb-1", class "placeholder-wave" ] [ span [ class "placeholder", class "col-2", class "me-1" ] [], span [ class "placeholder", class "col-3" ] [] ]
         , div [ class "mb-1", class "placeholder-wave" ] [ span [ class "placeholder", class "col-1", class "me-1" ] [], span [ class "placeholder", class "col-2" ] [] ]
-        , span [ class "badge", class "rounded-pill", class "me-1", class "placeholder", class "placeholder-wave", class "text-bg-secondary", class "text-secondary" ] [ text "STUDENT-UGRAD" ]
-        , span [ class "badge", class "rounded-pill", class "me-1", class "placeholder", class "placeholder-wave", class "text-bg-secondary", class "text-secondary" ] [ text "STUDENT-UGRAD" ]
-        , span [ class "badge", class "rounded-pill", class "me-1", class "placeholder", class "placeholder-wave", class "text-bg-secondary", class "text-secondary" ] [ text "STUDENT-UGRAD" ]
-        , span [ class "badge", class "rounded-pill", class "me-1", class "placeholder", class "placeholder-wave", class "text-bg-secondary", class "text-secondary" ] [ text "STUDENT-UGRAD" ]
+        , span [ class "badge", class "rounded-pill", class "me-1", class "placeholder", class "placeholder-wave", class "text-bg-secondary", class "text-secondary" ] [ text "former-employee-recent-3yr" ]
+        , span [ class "badge", class "rounded-pill", class "me-1", class "placeholder", class "placeholder-wave", class "text-bg-secondary", class "text-secondary" ] [ text "full-time-employee" ]
+        , span [ class "badge", class "rounded-pill", class "me-1", class "placeholder", class "placeholder-wave", class "text-bg-secondary", class "text-secondary" ] [ text "former-credit-student" ]
         ]
 
 
@@ -2031,7 +2030,7 @@ viewPerson model =
                                                             List.map (\groupName -> span [ class "badge", class "rounded-pill", class "text-bg-primary", class "me-1" ] [ text groupName ]) groups
 
                                                         Nothing ->
-                                                            [ span [ class "placeholder", class "placeholder-wave", class "badge", class "rounded-pill", class "text-bg-secondary", class "text-secondary", class "me-1" ] [ text "robowrestling" ] ]
+                                                            [ span [ class "placeholder", class "placeholder-wave", class "badge", class "rounded-pill", class "text-bg-secondary", class "text-secondary" ] [ text "robowrestling" ] ]
 
                                                 Nothing ->
                                                     []
@@ -2070,7 +2069,7 @@ viewPerson model =
                                                             List.map (\groupName -> span [ class "badge", class "rounded-pill", class "text-bg-primary", class "me-1" ] [ text groupName ]) (List.sort (List.filterMap (\groupName -> Dict.get groupName groupNameMap) (Maybe.withDefault [] (Dict.get "memberOf" account.attributes))))
 
                                                         Nothing ->
-                                                            [ span [ class "placeholder", class "placeholder-wave", class "badge", class "rounded-pill", class "text-bg-secondary", class "text-secondary", class "me-1" ] [ text "robowrestling" ] ]
+                                                            [ span [ class "placeholder", class "placeholder-wave", class "badge", class "rounded-pill", class "text-bg-secondary", class "text-secondary" ] [ text "robowrestling" ] ]
 
                                                 Nothing ->
                                                     []
@@ -2176,7 +2175,7 @@ viewPerson model =
                                                             []
 
                                                         Nothing ->
-                                                            [ span [ class "placeholder", class "placeholder-wave", class "badge", class "rounded-pill", class "text-bg-secondary", class "text-secondary", class "me-1" ] [ text "disabled" ] ]
+                                                            [ span [ class "placeholder", class "placeholder-wave", class "badge", class "rounded-pill", class "text-bg-secondary", class "text-secondary" ] [ text "disabled" ] ]
 
                                                 Nothing ->
                                                     []
@@ -2223,7 +2222,7 @@ viewPerson model =
                                                             [ div [] (List.map whitepagesEntryToEmployeeTypePill entries) ]
 
                                                         Nothing ->
-                                                            [ span [ class "placeholder", class "placeholder-wave", class "badge", class "rounded-pill", class "text-bg-secondary", class "text-secondary", class "me-1" ] [ text "Temporary Employee" ] ]
+                                                            [ span [ class "placeholder", class "placeholder-wave", class "badge", class "rounded-pill", class "text-bg-secondary", class "text-secondary", class "me-1" ] [ text "employee" ] ]
 
                                                 Nothing ->
                                                     []
@@ -2807,7 +2806,7 @@ googleGroupsProvisioning model =
 
                 Just (Ok Nothing) ->
                     if getGoogleWorkspacePrimaryEmail model == "" then
-                        span [ class "text-secondary" ] [ text "User does not have an Apiary account" ]
+                        span [ class "text-secondary" ] [ text "No Apiary account" ]
 
                     else
                         table [ class "table" ]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Walkthrough

<a href="https://cursor.com/agents/bc-c0f6c68f-a34c-4c9d-8dc1-62dbe6cb4d68/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Floading_to_loaded_transition.mp4"><img src="https://cursor.com/artifacts/c/art-a51e556b-f0f9-41a0-bce4-ec993830bf02" alt="loading_to_loaded_transition.mp4" /></a>

Loading-to-loaded transition for `kberzinch3` with Slow 4G throttling — directory cards transition from `Loading...` skeleton to final data, and the events table transitions from skeleton rows to real events.

![Directory cards in loading state with Loading... text and placeholder badges, plus events table skeleton](https://cursor.com/artifacts/c/art-dca969d9-117f-46f8-8634-b6f5e7a254cc)

Loading state: each directory card (Apiary, Grouper, GTAD, GTED, Keycloak, Whitepages) shows `Loading...` text with `text-secondary` + `placeholder-wave`, plus a badge-shaped pill placeholder reserving the final layout. The Google Groups and SUMS provisioning rows show `Loading...` instead of an unlabeled bar. The Events table now renders 3 skeleton rows.

![Directory cards fully loaded showing real data and No account / No entries empty states](https://cursor.com/artifacts/c/art-19e19851-b0ae-468b-b50b-319eba9e6355)

Loaded state: data populates in place with no layout shift. Empty states (`No account`, `No entries`) render in `text-secondary`.

## Summary

Apply the new UI style guide (`/.cursor/rules/ui-style-guide.mdc`) to directory cards, search result placeholders, and the events table. Focus areas:

1. Loading states say `Loading...` (with `text-secondary` + `placeholder-wave`) instead of unlabeled placeholder bars.
2. Empty / no-data states use lower-emphasis `text-secondary` text consistently.
3. Placeholder badges keep their final shape (badge + pill classes + `text-bg-secondary`) and are populated with the longest likely text so they don't cause layout shift when real data lands.

## Changes

`elm/Main.elm`:

- **Directory cards (Apiary, Grouper, GTAD, GTED, Keycloak, Whitepages)**:
  - Wrapped every `No X` empty-state message with `text-secondary`.
  - Replaced the unlabeled placeholder bar in the count line with `Loading...` text in the style-guide loading style.
  - Replaced the unlabeled rounded-pill placeholder badges with badge placeholders that include `text-bg-secondary`, `text-secondary`, and longest-likely text (`robowrestling` for Grouper / GTAD groups, `affiliate` for GTED affiliation, `disabled` for Keycloak status, `Temporary Employee` for Whitepages employee type).
- **Search result placeholder**: pills now use the badge placeholder style and the longest likely affiliation string (`STUDENT-UGRAD`).
- **Google Groups and SUMS billing groups**: loading placeholders now show `Loading...` instead of an unlabeled bar.
- **Events table**:
  - Added an `eventRowPlaceholder` skeleton row used while events are still loading.
  - Added a `No events` empty-state row (using `text-secondary`) when the API returns an empty list.

## Testing

- elm-review (passes via `npm run build`)
- elm-format --validate (passes via `npm run build`)
- Optimized Elm build + terser (passes via `npm run build`)
- Manual end-to-end: signed in to a local Checkpoint instance as `testuser`, viewed `kberzinch3` (real GTED account) and `some-fake-id` (no GTED match) under Slow 4G to confirm loading skeletons, real data, and `No account` / `No entries` empty states all render per the style guide.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c0f6c68f-a34c-4c9d-8dc1-62dbe6cb4d68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c0f6c68f-a34c-4c9d-8dc1-62dbe6cb4d68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

