### PR TITLE
Recognize Keycloak REGISTER events in event log

### DIFF
--- a/checkpoint.py
+++ b/checkpoint.py
@@ -1982,14 +1982,14 @@ def get_events(directory_id: str) -> List[Dict[str, Any]]:
                 description = "logged into " + client_id
             elif event["type"] == "CODE_TO_TOKEN":
                 description = "logged into " + client_id
+            elif event["type"] == "REGISTER":
+                description = "logged into " + client_id
             elif event["type"] == "LOGOUT":
                 description = "logged out of " + client_id
             elif event["type"] == "LOGIN_ERROR":
                 description = "failed to log into " + client_id
             elif event["type"] == "LOGOUT_ERROR":
                 description = "failed to log out of " + client_id
-            elif event["type"] == "REGISTER":
-                description = "registered through " + client_id
             else:
                 print(dumps(event))
                 raise InternalServerError("Unrecognized type in Keycloak event: " + event["type"])

--- a/checkpoint.py
+++ b/checkpoint.py
@@ -1988,6 +1988,8 @@ def get_events(directory_id: str) -> List[Dict[str, Any]]:
                 description = "failed to log into " + client_id
             elif event["type"] == "LOGOUT_ERROR":
                 description = "failed to log out of " + client_id
+            elif event["type"] == "REGISTER":
+                description = "registered through " + client_id
             else:
                 print(dumps(event))
                 raise InternalServerError("Unrecognized type in Keycloak event: " + event["type"])


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds an `elif` branch in `get_events` so that Keycloak user events of type `REGISTER` (emitted when an account is provisioned via an identity provider broker, e.g. CAS into the `workspace-onboarding` client) are rendered in the event log instead of bubbling up as `Unrecognized type in Keycloak event`.

The new branch mirrors the format of the existing `LOGIN` / `LOGOUT` / `LOGIN_ERROR` / `LOGOUT_ERROR` handlers and produces a description like `registered through workspace-onboarding`.

## Testing

- `poetry run black --check checkpoint.py`
- `poetry run flake8 checkpoint.py`
- `poetry run pylint checkpoint.py`
- `poetry run mypy --strict --scripts-are-modules checkpoint.py`
- Ran a standalone simulation of the if/elif chain with the sample event from the task description and confirmed the description resolves to `registered through workspace-onboarding`.

End-to-end manual reproduction of a REGISTER event would require a Keycloak identity-provider broker (CAS) connected to a real GT account, which is not reachable from the cloud VM. The change is a 2-line additive branch matching the existing patterns and all linters pass.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4af11773-5aa3-4101-b378-95baf0770cb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4af11773-5aa3-4101-b378-95baf0770cb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

