### PR TITLE
Deduplicate identical events in the user view

### DIFF
--- a/elm/Main.elm
+++ b/elm/Main.elm
@@ -2243,7 +2243,7 @@ viewPerson model =
                                                     [ tr [] [ td [ class "text-secondary", class "border-0" ] [ text "No events" ] ] ]
 
                                                 else
-                                                    List.map (eventToHtmlRow model.zone model.zoneName) (List.sortWith sortByEventTimestamp events)
+                                                    List.map (eventToHtmlRow model.zone model.zoneName) (dedupEvents (List.sortWith sortByEventTimestamp events))
 
                                             Just (Err _) ->
                                                 []
@@ -2421,6 +2421,50 @@ eventToHtmlRow zone zoneName event =
 sortByEventTimestamp : Event -> Event -> Order
 sortByEventTimestamp first second =
     compare (Time.posixToMillis second.eventTimestamp) (Time.posixToMillis first.eventTimestamp)
+
+
+eventDedupKey : Event -> String
+eventDedupKey event =
+    let
+        maybeKey : Maybe String -> String
+        maybeKey m =
+            case m of
+                Just s ->
+                    "J" ++ s
+
+                Nothing ->
+                    "N"
+    in
+    String.fromInt (Time.posixToMillis event.eventTimestamp // 60000)
+        ++ "\u{0000}"
+        ++ event.actorDisplayName
+        ++ "\u{0000}"
+        ++ maybeKey event.actorLink
+        ++ "\u{0000}"
+        ++ event.eventDescription
+        ++ "\u{0000}"
+        ++ maybeKey event.eventLink
+
+
+dedupEvents : List Event -> List Event
+dedupEvents events =
+    List.foldl
+        (\event ( seen, acc ) ->
+            let
+                key : String
+                key =
+                    eventDedupKey event
+            in
+            if Set.member key seen then
+                ( seen, acc )
+
+            else
+                ( Set.insert key seen, event :: acc )
+        )
+        ( Set.empty, [] )
+        events
+        |> Tuple.second
+        |> List.reverse
 
 
 eventRowPlaceholder : Html msg


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Some data sources (notably Keycloak) emit multiple events for a single user action that render identically in the UI. This frontend-only change adds an order-preserving dedup step in `elm/Main.elm` keyed off the same fields the UI actually renders, so visible duplicates collapse to a single row.

## Approach

- Added `eventDedupKey : Event -> String` next to `sortByEventTimestamp`. The key concatenates the rendered fields with NUL separators:
  - `Time.posixToMillis event.eventTimestamp // 60000` (minute bucket; the rendered timestamp omits seconds, and all real-world `Time.Zone` offsets are minute-aligned so the bucket matches the rendered minute in any zone)
  - `actorDisplayName`
  - `actorLink` (with `J`/`N` prefix so `Just ""` and `Nothing` stay distinguishable)
  - `eventDescription`
  - `eventLink` (with the same `J`/`N` prefix)
- Added `dedupEvents : List Event -> List Event`, an order-preserving fold over `Set String` of seen keys. A `Set`-based fold (rather than "dedupe consecutive after sort") is required because `sortByEventTimestamp` sorts by full millis, so two duplicates that differ by a few seconds can be separated by an unrelated event.
- Wired it in at the single render site: `dedupEvents (List.sortWith sortByEventTimestamp events)`. The first occurrence in sorted order survives.

No backend changes.

## Testing

- `npm run build-debug` (Elm compiler clean)
- `npx elm-review` (no errors)
- `npx elm-format --validate elm/Main.elm` (clean)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e64658a3-f0c5-4979-8897-1dba93975784"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e64658a3-f0c5-4979-8897-1dba93975784"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

