### PR TITLE
Persist Keycloak users and Slack user IDs into Crosswalk

### DIFF
--- a/checkpoint.py
+++ b/checkpoint.py
@@ -536,18 +536,22 @@ def get_actor(**kwargs: str) -> Dict[str, Union[str, None]]:
                 )
                 keycloak_response.raise_for_status()
 
+                keycloak_account = keycloak_response.json()
+
                 if (
                     fullmatch(
                         GEORGIA_TECH_USERNAME_REGEX,
-                        keycloak_response.json()["username"],
+                        keycloak_account["username"],
                         IGNORECASE,
                     )
                     is not None
                 ):
-                    return get_actor(uid=keycloak_response.json()["username"])  # type: ignore
+                    actor = get_actor(uid=keycloak_account["username"])
+                    update_crosswalk_from_keycloak_user(keycloak_account)
+                    return actor  # type: ignore
 
                 return {
-                    "actorDisplayName": keycloak_response.json()["username"],
+                    "actorDisplayName": keycloak_account["username"],
                     "actorLink": urlunparse(
                         (
                             urlparse(app.config["KEYCLOAK_METADATA_URL"]).scheme,
@@ -555,11 +559,7 @@ def get_actor(**kwargs: str) -> Dict[str, Union[str, None]]:
                             "/admin/master/console/",
                             "",
                             "",
-                            "/"
-                            + realm["realm"]
-                            + "/users/"
-                            + keycloak_response.json()["id"]
-                            + "/settings",
+                            "/" + realm["realm"] + "/users/" + keycloak_account["id"] + "/settings",
                         )
                     ),
                 }
@@ -917,6 +917,73 @@ def fuzzy_search_apiary(query: str) -> List[Dict[str, Any]]:
     return users
 
 
+def update_crosswalk_from_keycloak_user(account: Dict[str, Any]) -> None:
+    """
+    Upsert the Keycloak identifiers and email addresses from a Keycloak user object
+    into Crosswalk, anchored on the row whose primary_username matches the Keycloak
+    username.
+    """
+    if account.get("username") is None:
+        return
+
+    cursor = db().execute(
+        "SELECT gt_person_directory_id FROM crosswalk WHERE primary_username = (:username)",
+        {"username": account["username"]},
+    )
+    row = cursor.fetchone()
+
+    if row is None:
+        return
+
+    if account.get("id") is not None:
+        db().execute(
+            (
+                "UPDATE crosswalk SET keycloak_user_id = (:keycloak_user_id)"
+                " WHERE gt_person_directory_id = (:gt_person_directory_id)"
+            ),
+            {
+                "keycloak_user_id": account["id"],
+                "gt_person_directory_id": row[0],
+            },
+        )
+
+    for email_address in (
+        account.get("email"),
+        get_attribute_value("googleWorkspaceAccount", account),
+        get_attribute_value("rampLoginEmailAddress", account),
+    ):
+        if email_address is None:
+            continue
+
+        db().execute(
+            (
+                "INSERT INTO crosswalk_email_address (email_address, gt_person_directory_id)"  # noqa
+                " VALUES (:email_address, :gt_person_directory_id)"
+                " ON CONFLICT DO UPDATE SET gt_person_directory_id = (:gt_person_directory_id) WHERE email_address = (:email_address)"  # noqa
+            ),
+            {
+                "email_address": email_address,
+                "gt_person_directory_id": row[0],
+            },
+        )
+
+
+def update_crosswalk_slack_user_id(slack_user_id: str, gt_person_directory_id: str) -> None:
+    """
+    Persist the mapping from a Slack user ID to a known gtPersonDirectoryId.
+    """
+    db().execute(
+        (
+            "UPDATE crosswalk SET slack_user_id = (:slack_user_id)"
+            " WHERE gt_person_directory_id = (:gt_person_directory_id)"
+        ),
+        {
+            "slack_user_id": slack_user_id,
+            "gt_person_directory_id": gt_person_directory_id,
+        },
+    )
+
+
 def clean_affiliations(affiliations: List[str]) -> List[str]:
     """
     Remove redundant or confusing affiliations from search results
@@ -1233,7 +1300,8 @@ CREATE TABLE IF NOT EXISTS crosswalk (
     primary_username TEXT NOT NULL UNIQUE COLLATE NOCASE,
     keycloak_user_id TEXT UNIQUE COLLATE NOCASE,
     google_workspace_user_id TEXT UNIQUE COLLATE NOCASE,
-    apiary_user_id INTEGER UNIQUE
+    apiary_user_id INTEGER UNIQUE,
+    slack_user_id TEXT UNIQUE COLLATE NOCASE
 ) strict;
 
 CREATE TABLE IF NOT EXISTS crosswalk_email_address (
@@ -1818,7 +1886,10 @@ def get_keycloak_account(directory_id: str, is_frontend_request: bool = True) ->
         )
         keycloak_response.raise_for_status()
 
-        return keycloak_response.json()  # type: ignore
+        keycloak_account = keycloak_response.json()
+        update_crosswalk_from_keycloak_user(keycloak_account)
+
+        return keycloak_account  # type: ignore
 
     cursor = db().execute(
         "SELECT primary_username FROM crosswalk WHERE gt_person_directory_id = (:directory_id)",
@@ -3666,6 +3737,8 @@ def handle_event_callback(body: Dict[str, Any]) -> Dict[str, str]:
     if len(lookup_results["results"]) == 0:
         return {"status": "ok"}
 
+    update_crosswalk_slack_user_id(lookup_user_id, lookup_results["results"][0]["directoryId"])
+
     blocks = format_search_result_blocks(lookup_results)
 
     ephemeral_users = app.config.get("SLACK_EPHEMERAL_USERS", "")
@@ -3720,6 +3793,8 @@ def slack_user_has_access(user_id: str) -> bool:
 
     if len(triggering_user_results["results"]) == 0:
         return False
+
+    update_crosswalk_slack_user_id(user_id, triggering_user_results["results"][0]["directoryId"])
 
     keycloak_account = get_keycloak_account(
         triggering_user_results["results"][0]["directoryId"], is_frontend_request=False
@@ -3825,6 +3900,9 @@ def handle_slack_search_request(payload: Dict[str, Any]) -> None:
         )
 
     lookup_results = search_by_email(Address(addr_spec=lookup_email))
+
+    if len(lookup_results["results"]) > 0:
+        update_crosswalk_slack_user_id(lookup_user_id, lookup_results["results"][0]["directoryId"])
 
     slack.views_open(
         trigger_id=payload["trigger_id"],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes three of the Crosswalk persistence gaps identified during the recent audit:

- **Gap 4 — `get_keycloak_account` direct fetch.** When the function fetches a Keycloak user directly by `keycloak_user_id`, the returned `email`, `googleWorkspaceAccount`, and `rampLoginEmailAddress` are now persisted to `crosswalk_email_address`.
- **Gap 5 — `get_actor` Keycloak branch.** When the function fetches a Keycloak user from a `realmId`/`userId` pair, the Keycloak `id`, `email`, `googleWorkspaceAccount`, and `rampLoginEmailAddress` are now persisted (after recursing through `get_actor(uid=…)`, which populates the underlying `crosswalk` row via `search_gted`).
- **Gap 9 — Slack `users_info`.** A new `slack_user_id` column (`TEXT UNIQUE COLLATE NOCASE`, nullable) is added to the `crosswalk` table, and the Slack user ID returned by `slack.users_info(...)` is now stored in all three call sites: `handle_event_callback`, `slack_user_has_access`, and `handle_slack_search_request`.

## Implementation

Two new helpers were added next to `update_crosswalk_from_apiary_user`:

- `update_crosswalk_from_keycloak_user(account)` — anchors on the row whose `primary_username` matches the Keycloak `username`; updates `keycloak_user_id` and inserts the `email`, `googleWorkspaceAccount`, and `rampLoginEmailAddress` into `crosswalk_email_address`.
- `update_crosswalk_slack_user_id(slack_user_id, gt_person_directory_id)` — sets `slack_user_id` on the row identified by `gt_person_directory_id`. Each Slack handler resolves the directory ID via the result of `search_by_email(...)` before calling the helper.

The schema change is reflected in `migrate()`. Per `AGENTS.md`, the SQLite database is reset per deployment, so the new column will be picked up on next migration.

## Out of scope

The remaining gaps from the audit are intentionally left for a follow-up.

## Testing

Linters all pass:

- `poetry run black --check checkpoint.py`
- `poetry run flake8 checkpoint.py`
- `poetry run pylint checkpoint.py` (10.00/10)
- `poetry run mypy --strict --scripts-are-modules checkpoint.py`

End-to-end integration tests were run against a live Apiary tenant and a local Keycloak (Docker, with `unmanagedAttributePolicy: ENABLED` and a `kberzinch3` user that mirrors production):

1. `update_crosswalk_from_keycloak_user` and `update_crosswalk_slack_user_id` were exercised directly; the `slack_user_id` `UNIQUE` constraint also fired as expected on a duplicate insert.
2. `get_keycloak_account(directory_id)` direct-fetch path: confirmed `gap4-keycloak-email@example.com`, `gap4-gws@example.com`, and `gap4-ramp@example.com` all land in `crosswalk_email_address` after the call.
3. `get_actor(realmId=…, userId=…)`: confirmed the same three Keycloak emails plus `kristaps@gatech.edu` (added by the recursive `search_gted`) land in `crosswalk_email_address`, and `keycloak_user_id` is set on the row.

Per the `slack-demo` workspace rule, no live Slack integration test was run; the three Slack handlers were verified by static review of the call sites and by exercising the underlying helper directly against the database.

Test transcript:

[crosswalk_persistence_tests.log](https://cursor.com/artifacts/c/art-03b0b196-4cc1-4aff-95f2-94f59c7710e4)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d2c79be8-8017-45cd-8c05-2e5e9cab5e25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d2c79be8-8017-45cd-8c05-2e5e9cab5e25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

