### PR TITLE
Handle CHANGE_USER_RELATION Google Workspace admin event

### DIFF
--- a/checkpoint.py
+++ b/checkpoint.py
@@ -3219,6 +3219,53 @@ def get_events(directory_id: str) -> List[Dict[str, Any]]:
                             + get_parameter_value("NEW_VALUE", item["events"][0]["parameters"])
                         )
 
+                    elif (
+                        "name" in item["events"][0]
+                        and item["events"][0]["name"] == "CHANGE_USER_RELATION"
+                    ):
+                        user_email = get_parameter_value(
+                            "USER_EMAIL", item["events"][0]["parameters"]
+                        )
+                        old_value = get_parameter_value(
+                            "OLD_VALUE", item["events"][0]["parameters"]
+                        ).strip('"')
+                        new_value = get_parameter_value(
+                            "NEW_VALUE", item["events"][0]["parameters"]
+                        ).strip('"')
+
+                        user_display_name = get_actor(
+                            email=user_email, customer_id=item["id"]["customerId"]
+                        )["actorDisplayName"]
+
+                        if new_value:
+                            new_relation_type, _, new_relation_email = new_value.partition(":")
+                            new_relation_display_name = get_actor(
+                                email=new_relation_email, customer_id=item["id"]["customerId"]
+                            )["actorDisplayName"]
+                            event_description = (
+                                "updated "
+                                + str(user_display_name)
+                                + "'s "
+                                + new_relation_type.lower()
+                                + " to "
+                                + str(new_relation_display_name)
+                                + " in Google Workspace"
+                            )
+                        else:
+                            old_relation_type, _, old_relation_email = old_value.partition(":")
+                            old_relation_display_name = get_actor(
+                                email=old_relation_email, customer_id=item["id"]["customerId"]
+                            )["actorDisplayName"]
+                            event_description = (
+                                "removed "
+                                + str(user_display_name)
+                                + "'s "
+                                + old_relation_type.lower()
+                                + " (was "
+                                + str(old_relation_display_name)
+                                + ") in Google Workspace"
+                            )
+
                     else:
                         raise InternalServerError(
                             "Unable to determine admin event type: " + dumps(item)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The `/events` endpoint raised `InternalServerError("Unable to determine admin event type: ...")` whenever Google Workspace reported a `CHANGE_USER_RELATION` admin event (for example, setting a user's manager via the Admin SDK).

This change adds a dedicated branch in the admin Reports activity loop in `checkpoint.py` so the event renders as a human-readable description instead of failing the request.

## Behavior

For each `CHANGE_USER_RELATION` event:

- Reads `USER_EMAIL`, `OLD_VALUE`, and `NEW_VALUE` via `get_parameter_value`.
- Strips the literal `"` characters that the Reports API wraps around `OLD_VALUE` / `NEW_VALUE`.
- Splits the remaining `RELATION_TYPE:email` value on the first `:` and lowercases the relation type.
- Resolves the subject email and the related email through `get_actor(email=..., customer_id=...)` so the description shows full names rather than raw email addresses, falling back to the Google Workspace directory via the customer ID when the address is not yet in the crosswalk.

Description format:

- `NEW_VALUE` non-empty (set or change): `updated <user>'s <relation_type> to <new_relation_name> in Google Workspace`
- `NEW_VALUE` empty, `OLD_VALUE` non-empty (removal): `removed <user>'s <relation_type> (was <old_relation_name>) in Google Workspace`

For the production event from the bug report this now produces:

> updated Jacques Wang's manager to Will Hoffman in Google Workspace

## Testing

- `poetry run black --check checkpoint.py`
- `poetry run flake8 checkpoint.py`
- `poetry run pylint checkpoint.py` (10.00/10)
- `poetry run mypy --strict --scripts-are-modules checkpoint.py`

End-to-end exercise of `/events` is not practical here: it requires real Google Workspace service-account credentials plus a live Reports API stream that happens to include a `CHANGE_USER_RELATION` event. The new code is a pure-Python string-building branch that uses the same parameter / actor helpers as the neighboring `ADD_GROUP_MEMBER`, `MOVE_USER_TO_ORG_UNIT`, etc. handlers, so lint plus targeted review of the branch is the proportional verification.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-964e7ea8-ff25-47a4-b77d-8be17de726f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-964e7ea8-ff25-47a4-b77d-8be17de726f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

