### PR TITLE
Align empty Events state with section heading

### DIFF
--- a/elm/Main.elm
+++ b/elm/Main.elm
@@ -2125,23 +2125,31 @@ viewPerson model =
                             ]
                         ]
                    , h5 [ class "mt-4", class "mb-3" ] [ text "Events " ]
-                   , div [ class "row" ]
-                        [ table [ class "table" ]
-                            [ tbody []
-                                (case model.selectedDirectoryId of
-                                    Just _ ->
-                                        case model.events of
-                                            Just (Ok events) ->
-                                                if List.isEmpty events then
-                                                    [ tr [] [ td [ class "text-secondary", class "border-0" ] [ text "No events" ] ] ]
+                   , (case model.selectedDirectoryId of
+                        Just _ ->
+                            case model.events of
+                                Just (Ok events) ->
+                                    if List.isEmpty events then
+                                        div [ class "text-secondary" ] [ text "No events" ]
 
-                                                else
-                                                    List.map (eventToHtmlRow model.zone model.zoneName) (dedupEvents (List.sortWith sortByEventTimestamp events))
+                                    else
+                                        div [ class "row" ]
+                                            [ table [ class "table" ]
+                                                [ tbody []
+                                                    (List.map (eventToHtmlRow model.zone model.zoneName) (dedupEvents (List.sortWith sortByEventTimestamp events)))
+                                                ]
+                                            ]
 
-                                            Just (Err _) ->
-                                                []
+                                Just (Err _) ->
+                                    div [ class "row" ]
+                                        [ table [ class "table" ]
+                                            [ tbody [] [] ]
+                                        ]
 
-                                            Nothing ->
+                                Nothing ->
+                                    div [ class "row" ]
+                                        [ table [ class "table" ]
+                                            [ tbody []
                                                 [ tr [ class "opacity-75" ]
                                                     [ td [ style "width" "20%" ]
                                                         [ span [ class "placeholder", class "placeholder-wave", class "col-10", class "text-secondary" ] [] ]
@@ -2161,12 +2169,15 @@ viewPerson model =
                                                         [ span [ class "placeholder", class "placeholder-wave", class "col-6", class "text-secondary" ] [] ]
                                                     ]
                                                 ]
+                                            ]
+                                        ]
 
-                                    _ ->
-                                        []
-                                )
-                            ]
-                        ]
+                        _ ->
+                            div [ class "row" ]
+                                [ table [ class "table" ]
+                                    [ tbody [] [] ]
+                                ]
+                     )
                    ]
             )
         ]

--- a/elm/Main.elm
+++ b/elm/Main.elm
@@ -2125,7 +2125,7 @@ viewPerson model =
                             ]
                         ]
                    , h5 [ class "mt-4", class "mb-3" ] [ text "Events " ]
-                   , (case model.selectedDirectoryId of
+                   , case model.selectedDirectoryId of
                         Just _ ->
                             case model.events of
                                 Just (Ok events) ->
@@ -2177,7 +2177,6 @@ viewPerson model =
                                 [ table [ class "table" ]
                                     [ tbody [] [] ]
                                 ]
-                     )
                    ]
             )
         ]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When a person has no events, the "No events" message was rendered inside a Bootstrap table row within a `.row` wrapper. Table cell padding and row gutters caused it to sit misaligned with the "Events" heading.

This change renders the empty state as a plain `text-secondary` div (consistent with other empty states like "No entries" in Whitepages), while keeping the table layout for loading placeholders and populated event lists.

## Test plan

- [ ] Open a person with no events (e.g. username `abelessi3`)
- [ ] Confirm "No events" aligns with the "Events" heading
- [ ] Open a person with events and confirm the events table still renders correctly
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-082df213-5468-4d24-9f8b-cd98daa913a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-082df213-5468-4d24-9f8b-cd98daa913a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

