### PR TITLE
Conditionally show View in Grouper for PSA users in Slack

### DIFF
--- a/checkpoint.py
+++ b/checkpoint.py
@@ -1224,6 +1224,35 @@ def format_search_result_blocks(
             }
         ]
 
+    grouper_option = []
+    if slack_user_has_privilege_separated_account(viewer_slack_user_id):
+        grouper_option = [
+            {
+                "text": {"type": "plain_text", "text": "View in Grouper"},
+                "url": app.config["GROUPER_BASE_URL"]
+                + "/grouper/grouperUi/app/UiV2Main.index?operation=UiV2Subject.viewSubject&subjectId="  # noqa
+                + result_context["primaryUsername"]
+                + "&sourceId=gted-accounts",
+            }
+        ]
+
+    overflow_options = [
+        *iat_option,
+        *grouper_option,
+        *keycloak_button,
+        *google_workspace_button,
+    ]
+
+    overflow_menu = []
+    if len(overflow_options) > 0:
+        overflow_menu = [
+            {
+                "type": "overflow",
+                "action_id": "overflow_menu",
+                "options": overflow_options,
+            }
+        ]
+
     return [
         {
             "type": "section",
@@ -1243,22 +1272,7 @@ def format_search_result_blocks(
                     "action_id": "view_in_checkpoint",
                 },
                 *apiary_button,
-                {
-                    "type": "overflow",
-                    "action_id": "overflow_menu",
-                    "options": [
-                        *iat_option,
-                        {
-                            "text": {"type": "plain_text", "text": "View in Grouper"},
-                            "url": app.config["GROUPER_BASE_URL"]
-                            + "/grouper/grouperUi/app/UiV2Main.index?operation=UiV2Subject.viewSubject&subjectId="  # noqa
-                            + result_context["primaryUsername"]
-                            + "&sourceId=gted-accounts",
-                        },
-                        *keycloak_button,
-                        *google_workspace_button,
-                    ],
-                },
+                *overflow_menu,
             ],
         },
     ]
@@ -3878,6 +3892,34 @@ def slack_user_has_iat_access(slack_user_id: str) -> bool:
                 return True
 
     return False
+
+
+@cache.memoize()
+def slack_user_has_privilege_separated_account(slack_user_id: str) -> bool:
+    """
+    Check if a Slack user has a privilege separated GTED account
+    """
+    viewer_results = search_by_slack_user_id(
+        slack_user_id, with_gted=False, with_title_and_organization=False
+    )
+
+    if len(viewer_results["results"]) == 0:
+        return False
+
+    cursor = db().execute(
+        "SELECT primary_username FROM crosswalk WHERE gt_person_directory_id = (:directory_id)",
+        {"directory_id": viewer_results["results"][0]["directoryId"]},
+    )
+    row = cursor.fetchone()
+
+    if row is None:
+        return False
+
+    primary_username = row[0]
+
+    accounts = search_gted(filter=build_ldap_filter(uid="*-" + primary_username))
+
+    return len(accounts) > 0
 
 
 @shared_task

--- a/checkpoint.py
+++ b/checkpoint.py
@@ -310,6 +310,13 @@ def search_gted(**kwargs: str) -> List[Dict[str, Any]]:
         return []
 
     for account in buzzapi_response.json()["api_result_data"]:
+        if (
+            account.get("gtPersonDirectoryId") is None
+            or account.get("gtGTID") is None
+            or account.get("gtPrimaryGTAccountUsername") is None
+        ):
+            continue
+
         db().execute(
             (
                 "INSERT INTO crosswalk (gt_person_directory_id, gtid, primary_username)"
@@ -321,17 +328,19 @@ def search_gted(**kwargs: str) -> List[Dict[str, Any]]:
                 "primary_username": account["gtPrimaryGTAccountUsername"],
             },
         )
-        db().execute(
-            (
-                "INSERT INTO crosswalk_email_address (email_address, gt_person_directory_id)"  # noqa
-                " VALUES (:email_address, :gt_person_directory_id)"
-                " ON CONFLICT DO UPDATE SET gt_person_directory_id = (:gt_person_directory_id) WHERE email_address = (:email_address)"  # noqa
-            ),
-            {
-                "email_address": account["mail"],
-                "gt_person_directory_id": account["gtPersonDirectoryId"],
-            },
-        )
+
+        if account.get("mail") is not None:
+            db().execute(
+                (
+                    "INSERT INTO crosswalk_email_address (email_address, gt_person_directory_id)"  # noqa
+                    " VALUES (:email_address, :gt_person_directory_id)"
+                    " ON CONFLICT DO UPDATE SET gt_person_directory_id = (:gt_person_directory_id) WHERE email_address = (:email_address)"  # noqa
+                ),
+                {
+                    "email_address": account["mail"],
+                    "gt_person_directory_id": account["gtPersonDirectoryId"],
+                },
+            )
 
     return buzzapi_response.json()["api_result_data"]  # type: ignore
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Gate the Slack overflow menu's **View in Grouper** option on whether the requesting user has a privilege separated GTED account (uid formatted as `<prefix>-<primary username>`).
- Add `slack_user_has_privilege_separated_account()` to detect PSA accounts via `search_gted(filter=build_ldap_filter(uid="*-" + primary_username))`.
- Read the viewer's primary username from the crosswalk database (by `directory_id`) instead of making an extra GTED lookup.
- Omit the overflow menu entirely when it would have no options.

## Test plan

- [x] `poetry run black --check checkpoint.py`
- [x] `poetry run flake8 checkpoint.py`
- [x] `poetry run pylint checkpoint.py`
- [x] `poetry run mypy --strict --scripts-are-modules checkpoint.py`
- [x] Offline verification of three rendering cases:
  - Viewer with PSA sees **View in Grouper**
  - Viewer without PSA sees overflow without Grouper (when Keycloak option exists)
  - Viewer without PSA and no other options omits overflow entirely
- [x] PSA helper verified to use crosswalk `primary_username` and LDAP filter `(uid=*-<username>)`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8a58f111-8177-43ce-ac06-653ee4bdedfb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8a58f111-8177-43ce-ac06-653ee4bdedfb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

