### PR TITLE
Conditionally show View in Keycloak for Keycloak admins in Slack

### DIFF
--- a/checkpoint.py
+++ b/checkpoint.py
@@ -1194,7 +1194,9 @@ def format_search_result_blocks(
         ]
 
     keycloak_button = []
-    if result_context["keycloakUserId"] is not None:
+    if result_context["keycloakUserId"] is not None and slack_user_has_keycloak_admin_access(
+        viewer_slack_user_id
+    ):
         keycloak_button = [
             {
                 "text": {"type": "plain_text", "text": "View in Keycloak"},
@@ -4005,6 +4007,72 @@ def slack_user_has_privilege_separated_account(slack_user_id: str) -> bool:
     accounts = search_gted(filter=build_ldap_filter(uid="*-" + primary_username))
 
     return len(accounts) > 0
+
+
+@cache.memoize()
+def slack_user_has_keycloak_admin_access(slack_user_id: str) -> bool:
+    """
+    Check if a Slack user has the admin realm role in the Keycloak master realm
+    """
+    viewer_results = search_by_slack_user_id(
+        slack_user_id, with_gted=False, with_title_and_organization=False
+    )
+
+    if len(viewer_results["results"]) == 0:
+        return False
+
+    cursor = db().execute(
+        "SELECT primary_username FROM crosswalk WHERE gt_person_directory_id = (:directory_id)",
+        {"directory_id": viewer_results["results"][0]["directoryId"]},
+    )
+    row = cursor.fetchone()
+
+    if row is None:
+        return False
+
+    primary_username = row[0]
+
+    users_response = keycloak.get(
+        url=urlunparse(
+            (
+                urlparse(app.config["KEYCLOAK_METADATA_URL"]).scheme,
+                urlparse(app.config["KEYCLOAK_METADATA_URL"]).netloc,
+                "/admin/realms/master/users",
+                "",
+                "",
+                "",
+            )
+        ),
+        params={"username": primary_username, "exact": True},
+        timeout=(5, 5),
+    )
+    users_response.raise_for_status()
+
+    if len(users_response.json()) == 0:
+        return False
+
+    master_realm_user_id = users_response.json()[0]["id"]
+
+    role_mappings_response = keycloak.get(
+        url=urlunparse(
+            (
+                urlparse(app.config["KEYCLOAK_METADATA_URL"]).scheme,
+                urlparse(app.config["KEYCLOAK_METADATA_URL"]).netloc,
+                "/admin/realms/master/users/" + master_realm_user_id + "/role-mappings/realm",
+                "",
+                "",
+                "",
+            )
+        ),
+        timeout=(5, 5),
+    )
+    role_mappings_response.raise_for_status()
+
+    for mapping in role_mappings_response.json():
+        if mapping.get("name") == "admin":
+            return True
+
+    return False
 
 
 @shared_task


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The **View in Keycloak** option in Slack search results links into the Keycloak admin console, so it is only useful to people who can administer Keycloak. Previously it appeared for any viewer whenever the looked-up person had a Keycloak account.

This change gates that option on whether the **requesting/viewing** Slack user has admin access to Keycloak. Keycloak's administrative interface uses a separate admin role from the Checkpoint `access` role: RoboJackets identifies Keycloak admins by the **`admin` realm role in the `master` realm**.

## Changes

- Add `slack_user_has_keycloak_admin_access(slack_user_id)` (memoized) in `checkpoint.py`. It resolves the viewer to their GT `primary_username` (via the crosswalk, like the existing `slack_user_has_privilege_separated_account`), looks them up in the `master` realm by exact username match, and checks their direct realm role-mappings for a role named `admin`.
- Extend the `keycloak_button` condition in `format_search_result_blocks` to require both that the subject has a Keycloak account and that the viewer passes the admin check.

This mirrors the existing per-viewer gating for the IAT and Grouper options. Both Slack flows (the message-shortcut modal and the ephemeral search cards) already pass the viewer's Slack ID into `format_search_result_blocks`, so no caller/signature changes are needed.

## Notes

- The check targets the `master` realm explicitly (not `KEYCLOAK_REALM`). The `checkpoint-admin` service account already authenticates against the master realm and can read master-realm users and their role mappings.
- The `admin` role is assigned directly (not via group/composite), so direct realm role-mappings are read.

## Testing

- `poetry run black --check checkpoint.py`
- `poetry run flake8 checkpoint.py`
- `poetry run pylint checkpoint.py`
- `poetry run mypy --strict --scripts-are-modules checkpoint.py`
- Master-realm admin detection verified against a local Keycloak instance (no Slack integration testing, per repo convention).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-02228ba8-d10f-4d62-81b6-2ee4a1fded9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-02228ba8-d10f-4d62-81b6-2ee4a1fded9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

