### PR TITLE
Gate Slack Google Workspace button on viewer admin status

### DIFF
--- a/checkpoint.py
+++ b/checkpoint.py
@@ -1218,7 +1218,9 @@ def format_search_result_blocks(
         ]
 
     google_workspace_button = []
-    if result_context["googleWorkspacePrimaryEmail"] is not None:
+    if result_context[
+        "googleWorkspacePrimaryEmail"
+    ] is not None and slack_user_has_google_workspace_admin_access(viewer_slack_user_id):
         google_workspace_button = [
             {
                 "text": {"type": "plain_text", "text": "View in Google Workspace"},
@@ -4073,6 +4075,25 @@ def slack_user_has_keycloak_admin_access(slack_user_id: str) -> bool:
             return True
 
     return False
+
+
+@cache.memoize()
+def slack_user_has_google_workspace_admin_access(slack_user_id: str) -> bool:
+    """
+    Check if a Slack user is a Google Workspace admin (has isAdmin on their account)
+    """
+    viewer_results = search_by_slack_user_id(
+        slack_user_id, with_gted=False, with_title_and_organization=False
+    )
+
+    if len(viewer_results["results"]) == 0:
+        return False
+
+    google_workspace_account = get_google_workspace_account(
+        viewer_results["results"][0]["directoryId"], is_frontend_request=False
+    )
+
+    return google_workspace_account is not None and google_workspace_account.get("isAdmin") is True
 
 
 @shared_task


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Adds `slack_user_has_google_workspace_admin_access()` to check whether the requesting Slack user has `isAdmin` on their own Google Workspace account
- Gates the "View in Google Workspace" overflow option in Slack search results on that check, in addition to the searched person having a Workspace account

## Motivation

The Google Workspace button links to `admin.google.com`, which only Workspace admins can use. Other overflow options (Keycloak, IAT, Grouper) already gate on the viewer's privileges; this brings the Workspace button in line with that pattern.

## Changes

- `checkpoint.py`: new memoized helper following the existing `slack_user_has_*` pattern
- `format_search_result_blocks()`: requires both `googleWorkspacePrimaryEmail` on the search result and admin access for the viewer

## Testing

- `poetry run black --check checkpoint.py`
- `poetry run flake8 checkpoint.py`
- `poetry run pylint checkpoint.py`
- `poetry run mypy --strict --scripts-are-modules checkpoint.py`

Slack integration testing was not performed per project rules.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-43f84607-50bc-4627-8e9b-8fe8a20a6887"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-43f84607-50bc-4627-8e9b-8fe8a20a6887"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

